### PR TITLE
Decouple Classes

### DIFF
--- a/lib/features/accomplished/accomplished_page.dart
+++ b/lib/features/accomplished/accomplished_page.dart
@@ -1,14 +1,14 @@
 import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
-import 'package:todo_app/features/add_todo_page/add_todo_page.dart';
-import 'package:todo_app/state/app_state/app_state.dart';
-import 'package:todo_app/main.dart';
-import 'package:todo_app/utils/constants.dart';
-import 'package:todo_app/widgets/empty_list_placeholder.dart';
-import 'package:todo_app/widgets/header_item.dart';
-import 'package:todo_app/widgets/todo_grid_view.dart';
-import 'package:todo_app/widgets/todo_item.dart';
+
+import '../../state/app_state/app_state.dart';
+import '../../utils/constants.dart';
+import '../../widgets/empty_list_placeholder.dart';
+import '../../widgets/header_item.dart';
+import '../../widgets/todo_grid_view.dart';
+import '../../widgets/todo_item.dart';
+import '../home_page/home_page.dart';
 
 class AccomplishedPage extends StatelessWidget {
   static const route = 'accomplished';
@@ -16,45 +16,39 @@ class AccomplishedPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return StoreConnector<AppState, MainViewModel>(
-        model: MainViewModel(),
-        builder: (context, viewModel) {
-          final filteredList = viewModel.todoList.where((element) => element.isAccomplished == true);
-          return Scaffold(
-            body: Container(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (filteredList.isNotEmpty) ...[
-                    HeaderItem(headerTitle: accomplishedToDos),
-                    Expanded(
-                      child: TodoGridView(
-                        staggeredTiles: filteredList.map((e) {
-                          final titleDescriptionNotEmpty = e.description.length > 100 && e.title.isNotEmpty;
-                          return StaggeredTile.count(1, titleDescriptionNotEmpty ? 1.75 : 0.75);
-                        }).toList(),
-                        children: filteredList.map((todo) {
-                          return TodoItem(
-                            title: todo.title,
-                            description: todo.description,
-                            onPressed: (context) {
-                              Future.delayed(
-                                const Duration(milliseconds: 200),
-                                () => Navigator.of(context)
-                                    .pushNamed(AddTodo.route, arguments: AddTodoArguments(todo: todo)),
-                              );
-                            },
-                          );
-                        }).toList(),
-                      ),
+      model: MainViewModel(),
+      builder: (context, viewModel) {
+        final filteredList = viewModel.todoList.where((element) => element.isAccomplished == true);
+        return Scaffold(
+          body: Container(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (filteredList.isNotEmpty) ...[
+                  HeaderItem(headerTitle: accomplishedToDos),
+                  Expanded(
+                    child: TodoGridView(
+                      staggeredTiles: filteredList.map((e) {
+                        return StaggeredTile.count(1, e.description.length > 100 ? 1.75 : 0.75);
+                      }).toList(),
+                      children: filteredList.map((todo) {
+                        return TodoItem(
+                          title: todo.title,
+                          description: todo.description,
+                          onPressed: (context) => HomePage.navigateToUpdateTodo(context, todo),
+                        );
+                      }).toList(),
                     ),
-                  ] else ...[
-                    EmptyListPlaceHolder(placeHolderTitle: accomplishedEmpty),
-                  ],
+                  ),
+                ] else ...[
+                  EmptyListPlaceHolder(placeHolderTitle: accomplishedEmpty),
                 ],
-              ),
+              ],
             ),
-          );
-        });
+          ),
+        );
+      },
+    );
   }
 }

--- a/lib/features/active/active_page.dart
+++ b/lib/features/active/active_page.dart
@@ -1,17 +1,57 @@
 import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
-import 'package:todo_app/features/add_todo_page/add_todo_page.dart';
-import 'package:todo_app/state/app_state/app_state.dart';
-import 'package:todo_app/main.dart';
-import 'package:todo_app/utils/constants.dart';
-import 'package:todo_app/widgets/empty_list_placeholder.dart';
-import 'package:todo_app/widgets/header_item.dart';
-import 'package:todo_app/widgets/todo_grid_view.dart';
-import 'package:todo_app/widgets/todo_item.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../models/todo.dart';
+import '../../state/app_state/actions/todo_actions.dart';
+import '../../state/app_state/app_state.dart';
+import '../../utils/constants.dart';
+import '../../widgets/empty_list_placeholder.dart';
+import '../../widgets/header_item.dart';
+import '../../widgets/todo_grid_view.dart';
+import '../../widgets/todo_item.dart';
+import '../add_todo_page/add_todo_page.dart';
+import '../home_page/home_page.dart';
 
 class ActivePage extends StatelessWidget {
   static const route = 'active';
+
+  Widget displayFloatingButton(BuildContext context, {bool isActivePage}) {
+    return isActivePage
+        ? FloatingActionButton(
+            onPressed: () => _navigateToAddTodo(context, null),
+            tooltip: newTodo,
+            child: const Icon(Icons.add),
+          )
+        : null;
+  }
+
+  Future<void> _navigateToAddTodo(BuildContext context, Todo todo) async {
+    final result = await Navigator.of(context).pushNamed(AddTodo.route, arguments: AddTodoArguments(todo: todo))
+        as HomePageArguments;
+    final title = result.title;
+    final description = result.description;
+    final isAccomplished = result.isAccomplished;
+    Future.delayed(
+      const Duration(seconds: 1),
+      () {
+        if (result.todo == null && (title.isNotEmpty || description.isNotEmpty)) {
+          StoreProvider.dispatch<AppState>(
+            context,
+            AddTodoAction(
+              todo: Todo(
+                id: Uuid().v1(),
+                title: title,
+                description: description,
+                isAccomplished: isAccomplished,
+              ),
+            ),
+          );
+        }
+      },
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +59,12 @@ class ActivePage extends StatelessWidget {
       model: MainViewModel(),
       builder: (BuildContext context, viewModel) {
         final filteredList = viewModel.todoList.where((element) => element.isAccomplished == false);
+        final isActivePage = viewModel.pageIndex == 0;
         return Scaffold(
+          floatingActionButton: displayFloatingButton(
+            context,
+            isActivePage: isActivePage,
+          ),
           body: Container(
             padding: const EdgeInsets.symmetric(vertical: 16.0, horizontal: 8.0),
             child: Column(
@@ -30,22 +75,13 @@ class ActivePage extends StatelessWidget {
                   Expanded(
                     child: TodoGridView(
                       staggeredTiles: filteredList.map((e) {
-                        final titleDescriptionNotEmpty = e.description.length > 100 && e.title.isNotEmpty;
-                        return StaggeredTile.count(1, titleDescriptionNotEmpty ? 1.50 : 0.75);
+                        return StaggeredTile.count(1, e.description.length > 100 ? 1.75 : 0.75);
                       }).toList(),
                       children: filteredList.map((todo) {
                         return TodoItem(
                           title: todo.title,
                           description: todo.description,
-                          onPressed: (context) {
-                            Future.delayed(
-                              const Duration(milliseconds: 200),
-                              () => Navigator.of(context).pushNamed(
-                                AddTodo.route,
-                                arguments: AddTodoArguments(todo: todo),
-                              ),
-                            );
-                          },
+                          onPressed: (context) => HomePage.navigateToUpdateTodo(context, todo),
                         );
                       }).toList(),
                     ),

--- a/lib/features/add_todo_page/add_todo_page.dart
+++ b/lib/features/add_todo_page/add_todo_page.dart
@@ -1,10 +1,10 @@
 import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
-import 'package:todo_app/main.dart';
-import 'package:todo_app/models/todo.dart';
-import 'package:todo_app/state/app_state/actions/todo_actions.dart';
-import 'package:todo_app/state/app_state/app_state.dart';
-import 'package:uuid/uuid.dart';
+
+import '../../models/todo.dart';
+import '../../state/app_state/app_state.dart';
+import '../../utils/constants.dart';
+import '../home_page/home_page.dart';
 
 class AddTodoArguments {
   final Todo todo;
@@ -12,7 +12,6 @@ class AddTodoArguments {
   const AddTodoArguments({@required this.todo});
 }
 
-/// TODO: add checker for [Todo] isAccomplished field
 class AddTodo extends StatefulWidget {
   static const route = 'add_todo';
 
@@ -45,57 +44,32 @@ class _AddTodoState extends State<AddTodo> {
 
   void setChecked({bool value}) => setState(() => isChecked = value);
 
+  void _dispatchAction(BuildContext context) {
+    FocusScope.of(context).unfocus();
+    final todo = widget.args.todo;
+    final title = _titleController.text;
+    final description = _descriptionController.text;
+    Navigator.of(context)
+        .pop(HomePageArguments(todo, title: title, description: description, isAccomplished: isChecked));
+  }
+
   @override
   Widget build(BuildContext context) {
-    final todo = widget.args.todo;
     final textTheme = Theme.of(context).textTheme;
     return StoreConnector<AppState, MainViewModel>(
       model: MainViewModel(),
       builder: (BuildContext context, vm) {
         return WillPopScope(
           onWillPop: () async {
-            FocusScope.of(context).unfocus();
-            return Navigator.canPop(context);
+            _dispatchAction(context);
+            return true;
           },
           child: Scaffold(
             appBar: AppBar(
               backgroundColor: isChecked ? Colors.red : Colors.blue,
               leading: IconButton(
                 icon: const Icon(Icons.close),
-                onPressed: () {
-                  FocusScope.of(context).unfocus();
-                  final title = _titleController.text;
-                  final description = _descriptionController.text;
-                  if (widget.args.todo == null && (title.isNotEmpty || description.isNotEmpty)) {
-                    StoreProvider.dispatch<AppState>(
-                      context,
-                      AddTodoAction(
-                        todo: Todo(
-                          id: Uuid().v1(),
-                          title: title,
-                          description: description,
-                          isAccomplished: isChecked
-                        ),
-                      ),
-                    );
-                  } else if (todo != null) {
-                    StoreProvider.dispatch<AppState>(
-                      context,
-                      UpdateTodoAction(
-                        todo: Todo(
-                          id: todo.id,
-                          title: title,
-                          description: description,
-                          isAccomplished: isChecked,
-                        ),
-                      ),
-                    );
-                  }
-                  Future.delayed(
-                    const Duration(milliseconds: 200),
-                    () => Navigator.of(context).pop(),
-                  );
-                },
+                onPressed: () => _dispatchAction(context),
               ),
               actions: [
                 Theme(
@@ -116,7 +90,7 @@ class _AddTodoState extends State<AddTodo> {
                     controller: _titleController,
                     style: textTheme.subtitle1.copyWith(fontWeight: FontWeight.w800, fontSize: 18.0),
                     decoration: InputDecoration(
-                      hintText: 'Title',
+                      hintText: title,
                       border: InputBorder.none,
                       hintStyle: textTheme.subtitle1.copyWith(
                         color: Colors.grey[700],
@@ -130,7 +104,7 @@ class _AddTodoState extends State<AddTodo> {
                       controller: _descriptionController,
                       autofocus: _descriptionController.text.isEmpty,
                       decoration: InputDecoration(
-                        hintText: 'Note',
+                        hintText: note,
                         border: InputBorder.none,
                         hintStyle: textTheme.subtitle2.copyWith(
                           color: Colors.grey[700],

--- a/lib/features/home_page/home_page.dart
+++ b/lib/features/home_page/home_page.dart
@@ -1,0 +1,120 @@
+import 'package:async_redux/async_redux.dart';
+import 'package:flutter/material.dart';
+import 'package:todo_app/features/add_todo_page/add_todo_page.dart';
+import 'package:todo_app/state/app_state/actions/todo_actions.dart';
+
+import '../../models/todo.dart';
+import '../../state/app_state/actions/screen_changing_actions.dart';
+import '../../state/app_state/app_state.dart';
+import '../../utils/constants.dart';
+import '../../widgets/tile_item.dart';
+import '../accomplished/accomplished_page.dart';
+import '../active/active_page.dart';
+
+class HomePageArguments {
+  final Todo todo;
+  final String title;
+  final String description;
+  final bool isAccomplished;
+
+  HomePageArguments(this.todo, {this.title, this.description, this.isAccomplished});
+}
+
+class MainViewModel extends BaseModel<AppState> {
+  String title;
+  int pageIndex;
+  List<Todo> todoList;
+
+  MainViewModel();
+
+  /// must have super(equals: [variables here])
+  /// https://github.com/marcglasberg/async_redux/issues/69#issuecomment-626248496
+  MainViewModel.build({this.title, this.pageIndex, this.todoList}) : super(equals: [title, pageIndex, todoList]);
+
+  @override
+  BaseModel fromStore() =>
+      MainViewModel.build(title: state.title, pageIndex: state.pageIndex, todoList: state.todoList);
+}
+
+class HomePage extends StatelessWidget {
+  static const route = 'home';
+
+  /// Dispatches actions when a TileItem is tapped.
+  ///
+  /// * [newTitle] changes title; to be passed on [ChangeScreenAction]
+  /// * [newIndex] changes current index to identify which screen will be shown; to be passed on [ChangeScreenAction]
+  void _dispatchAction(BuildContext context, String newTitle, int newIndex) {
+    StoreProvider.dispatch(context, ChangeScreenAction(title: newTitle, pageIndex: newIndex));
+    Future.delayed(const Duration(milliseconds: 200), () => Navigator.pop(context));
+  }
+
+  static Future<void> navigateToUpdateTodo(BuildContext context, Todo todo) async {
+    final result = await Navigator.of(context).pushNamed(
+      AddTodo.route,
+      arguments: AddTodoArguments(todo: todo),
+    ) as HomePageArguments;
+    final resultTodo = result.todo;
+    final title = result.title;
+    final description = result.description;
+    final isAccomplished = result.isAccomplished;
+    Future.delayed(
+      const Duration(seconds: 1),
+      () {
+        if (resultTodo != null && (title.isNotEmpty || description.isNotEmpty)) {
+          StoreProvider.dispatch<AppState>(
+            context,
+            UpdateTodoAction(
+              todo: Todo(
+                id: resultTodo.id,
+                title: title,
+                description: description,
+                isAccomplished: isAccomplished,
+              ),
+            ),
+          );
+        }
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return StoreConnector<AppState, MainViewModel>(
+      model: MainViewModel(),
+      builder: (context, viewModel) {
+        final isActivePage = viewModel.pageIndex == 0;
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(
+              viewModel.title,
+              style: const TextStyle(fontSize: 16.0),
+            ),
+            backgroundColor: isActivePage ? Colors.blue : Colors.red,
+          ),
+          body: isActivePage ? ActivePage() : AccomplishedPage(),
+          drawer: Drawer(
+            child: ListView(
+              children: [
+                const SizedBox(height: kToolbarHeight),
+                TileItem(
+                  iconData: Icons.lightbulb_outline,
+                  title: active,
+                  onTap: (context) => _dispatchAction(context, active, 0),
+                  focusColor: Colors.blue[600],
+                  isSelected: isActivePage,
+                ),
+                TileItem(
+                  iconData: Icons.done_all_outlined,
+                  title: accomplished,
+                  onTap: (context) => _dispatchAction(context, accomplished, 1),
+                  focusColor: Colors.red[600],
+                  isSelected: !isActivePage,
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,42 +1,19 @@
-import 'dart:async';
-
 import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
-import 'package:todo_app/features/add_todo_page/add_todo_page.dart';
-import 'package:todo_app/state/app_state/app_state.dart';
-import 'package:todo_app/utils/constants.dart';
-import 'package:todo_app/widgets/tile_item.dart';
 
-import 'features/accomplished/accomplished_page.dart';
-import 'features/active/active_page.dart';
-import 'models/todo.dart';
-import 'state/app_state/actions/screen_changing_actions.dart';
-
-class MainViewModel extends BaseModel<AppState> {
-  String title;
-  int pageIndex;
-  List<Todo> todoList;
-
-  MainViewModel();
-
-  /// must have super(equals: [variables here])
-  /// https://github.com/marcglasberg/async_redux/issues/69#issuecomment-626248496
-  MainViewModel.build({this.title, this.pageIndex, this.todoList}) : super(equals: [title, pageIndex, todoList]);
-
-  @override
-  BaseModel fromStore() =>
-      MainViewModel.build(title: state.title, pageIndex: state.pageIndex, todoList: state.todoList);
-}
+import 'features/home_page/home_page.dart';
+import 'state/app_state/app_state.dart';
+import 'utils/app_router.dart';
 
 void main() {
   final store = Store<AppState>(initialState: AppState.initState());
-  runApp(MyApp(store: store));
+  runApp(TodoApp(store: store));
 }
 
-class MyApp extends StatelessWidget {
+class TodoApp extends StatelessWidget {
   final Store<AppState> store;
 
-  const MyApp({Key key, this.store}) : super(key: key);
+  const TodoApp({Key key, this.store}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -45,110 +22,9 @@ class MyApp extends StatelessWidget {
       child: MaterialApp(
         title: 'Flutter To Do',
         theme: ThemeData(primarySwatch: Colors.blue),
-        initialRoute: MyHomePage.route,
+        initialRoute: HomePage.route,
         onGenerateRoute: AppRouter.generateRoute,
       ),
     );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  static const route = 'home';
-
-  @override
-  _MyHomePageState createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  Widget displayFloatingButton({bool isActivePage}) {
-    return isActivePage
-        ? FloatingActionButton(
-            onPressed: () => _navigateToAddTodo(null),
-            tooltip: newTodo,
-            child: const Icon(Icons.add),
-          )
-        : null;
-  }
-
-  void _navigateToAddTodo(Todo todo) {
-    Future.delayed(
-      const Duration(milliseconds: 200),
-      () => Navigator.of(context).pushNamed(AddTodo.route, arguments: AddTodoArguments(todo: todo)),
-    );
-  }
-
-  /// Dispatches actions when a TileItem is tapped.
-  ///
-  /// * [newTitle] changes title; to be passed on [ChangeScreenAction]
-  /// * [newIndex] changes current index to identify which screen will be shown; to be passed on [ChangeScreenAction]
-  void _dispatchAction(String newTitle, int newIndex) {
-    StoreProvider.dispatch(context, ChangeScreenAction(title: newTitle, pageIndex: newIndex));
-    Future.delayed(const Duration(milliseconds: 200), () => Navigator.pop(context));
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return StoreConnector<AppState, MainViewModel>(
-      model: MainViewModel(),
-      builder: (context, viewModel) {
-        final pageIndex = viewModel.pageIndex;
-        final isActivePage = pageIndex == 0;
-        return Scaffold(
-          appBar: AppBar(
-            title: Text(
-              viewModel.title,
-              style: const TextStyle(fontSize: 16.0),
-            ),
-            backgroundColor: isActivePage ? Colors.blue : Colors.red,
-          ),
-          body: isActivePage ? ActivePage() : AccomplishedPage(),
-          floatingActionButton: displayFloatingButton(isActivePage: isActivePage),
-          drawer: Drawer(
-            child: ListView(
-              children: [
-                const SizedBox(height: kToolbarHeight),
-                TileItem(
-                  iconData: Icons.lightbulb_outline,
-                  title: active,
-                  onTap: (context) => _dispatchAction(active, 0),
-                  focusColor: Colors.blue[600],
-                  isSelected: isActivePage,
-                ),
-                TileItem(
-                  iconData: Icons.done_all_outlined,
-                  title: accomplished,
-                  onTap: (context) => _dispatchAction(accomplished, 1),
-                  focusColor: Colors.red[600],
-                  isSelected: !isActivePage,
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
-}
-
-class AppRouter {
-  static Route<dynamic> generateRoute(RouteSettings settings) {
-    switch (settings.name) {
-      case MyHomePage.route:
-        return MaterialPageRoute<dynamic>(builder: (BuildContext context) => MyHomePage());
-        break;
-      case ActivePage.route:
-        return MaterialPageRoute<dynamic>(builder: (BuildContext context) => ActivePage());
-      case AccomplishedPage.route:
-        return MaterialPageRoute<dynamic>(builder: (BuildContext context) => AccomplishedPage());
-      case AddTodo.route:
-        final args = settings.arguments as AddTodoArguments;
-        return MaterialPageRoute<dynamic>(builder: (BuildContext context) => AddTodo(args: args));
-      default:
-        return MaterialPageRoute<dynamic>(
-          builder: (_) => Scaffold(
-            body: Center(child: Text('No route defined for ${settings.name}')),
-          ),
-        );
-    }
   }
 }

--- a/lib/utils/app_router.dart
+++ b/lib/utils/app_router.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+import '../features/accomplished/accomplished_page.dart';
+import '../features/active/active_page.dart';
+import '../features/add_todo_page/add_todo_page.dart';
+import '../features/home_page/home_page.dart';
+
+class AppRouter {
+  static Route<dynamic> generateRoute(RouteSettings settings) {
+    switch (settings.name) {
+      case HomePage.route:
+        return MaterialPageRoute<dynamic>(builder: (BuildContext context) => HomePage());
+      case ActivePage.route:
+        return MaterialPageRoute<dynamic>(builder: (BuildContext context) => ActivePage());
+      case AccomplishedPage.route:
+        return MaterialPageRoute<dynamic>(builder: (BuildContext context) => AccomplishedPage());
+      case AddTodo.route:
+        final args = settings.arguments as AddTodoArguments;
+        return MaterialPageRoute<dynamic>(builder: (BuildContext context) => AddTodo(args: args));
+      default:
+        return MaterialPageRoute<dynamic>(
+          builder: (_) => Scaffold(
+            body: Center(child: Text('No route defined for ${settings.name}')),
+          ),
+        );
+    }
+  }
+}

--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -5,3 +5,5 @@ const String active = "Active";
 const String activeEmpty = "No Active To Do's!";
 const String activeToDos = "Active To Do's";
 const String newTodo = "New Todo";
+const String note = "Note";
+const String title = "Title";

--- a/lib/widgets/todo_item.dart
+++ b/lib/widgets/todo_item.dart
@@ -5,7 +5,7 @@ class TodoItem extends StatelessWidget {
   final String description;
   final Function(BuildContext) onPressed;
 
-  const TodoItem({Key key, this.title, this.description, this.onPressed}) : super(key: key);
+  const TodoItem({this.title, this.description, this.onPressed});
 
   @override
   Widget build(BuildContext context) {

--- a/test/async_redux_test.dart
+++ b/test/async_redux_test.dart
@@ -1,0 +1,62 @@
+import 'package:async_redux/async_redux.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:todo_app/models/todo.dart';
+import 'package:todo_app/state/app_state/actions/screen_changing_actions.dart';
+import 'package:todo_app/state/app_state/actions/todo_actions.dart';
+import 'package:todo_app/state/app_state/app_state.dart';
+
+void main() {
+  StoreTester<AppState> storeTester;
+
+  setUp(() {
+    storeTester = StoreTester<AppState>(initialState: AppState.initState());
+  });
+
+  test(
+    'should dispatch ChangeScreenAction',
+    () async {
+      // check initial values
+      expect(storeTester.state.title, 'Active');
+      expect(storeTester.state.pageIndex, 0);
+
+      // dispatch 1st action
+      storeTester.dispatch(ChangeScreenAction(title: 'Accomplished', pageIndex: 1));
+
+      // await result
+      TestInfo<AppState> info = await storeTester.wait(ChangeScreenAction);
+      // expect new values
+      expect(info.state.title, 'Accomplished');
+      expect(info.state.pageIndex, 1);
+
+      // dispatch 2nd action
+      storeTester.dispatch(ChangeScreenAction(title: 'Active', pageIndex: 0));
+      // await new result
+      info = await storeTester.wait(ChangeScreenAction);
+      // expect new values from new result
+      expect(info.state.title, 'Active');
+      expect(info.state.pageIndex, 0);
+    },
+  );
+
+  test(
+    'should Dispatch AddTodoAction',
+    () async {
+      expect(storeTester.state.todoList, isEmpty);
+
+      final newTodo = Todo(id: 'randomId', title: 'random title', description: 'random desc', isAccomplished: false);
+      storeTester.dispatch(AddTodoAction(todo: newTodo));
+
+      TestInfo<AppState> info = await storeTester.wait(AddTodoAction);
+
+      expect(info.state.todoList, <Todo>[newTodo]);
+
+      final anotherTodo =
+          Todo(id: 'randomId2', title: 'random title2', description: 'random desc2', isAccomplished: true);
+      storeTester.dispatch(AddTodoAction(todo: anotherTodo));
+
+      info = await storeTester.wait(AddTodoAction);
+
+      expect(info.state.todoList, <Todo>[newTodo, anotherTodo]);
+    },
+  );
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,122 +8,130 @@
 import 'package:async_redux/async_redux.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:todo_app/features/home_page/home_page.dart';
 import 'package:todo_app/main.dart';
 import 'package:todo_app/state/app_state/actions/screen_changing_actions.dart';
 import 'package:todo_app/state/app_state/app_state.dart';
+import 'package:todo_app/utils/app_router.dart';
 import 'package:todo_app/utils/constants.dart';
 import 'package:todo_app/widgets/tile_item.dart';
 
 void main() {
-  testWidgets('App State initial test', (WidgetTester tester) async {
-    final Store<AppState> store = Store<AppState>(initialState: AppState.initState());
-    final storeTester = StoreTester<AppState>.from(store);
-    expect(storeTester.state.pageIndex, 0);
-    expect(storeTester.state.todoList, isEmpty);
-    expect(storeTester.state.title, 'Active');
+  testWidgets(
+    'App State initial test',
+    (WidgetTester tester) async {
+      final Store<AppState> store = Store<AppState>(initialState: AppState.initState());
+      final storeTester = StoreTester<AppState>.from(store);
+      expect(storeTester.state.pageIndex, 0);
+      expect(storeTester.state.todoList, isEmpty);
+      expect(storeTester.state.title, 'Active');
 
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp(store: store));
+      // Build our app and trigger a frame.
+      await tester.pumpWidget(TodoApp(store: store));
 
-    // Verify active list is empty / empty active to do's caption displayed
-    expect(find.text(activeEmpty), findsOneWidget);
+      // Verify active list is empty / empty active to do's caption displayed
+      expect(find.text(activeEmpty), findsOneWidget);
 
-    // for future reference
-    // Verify that our counter starts at 0.
-    // expect(find.text('0'), findsOneWidget);
-    // expect(find.text('1'), findsNothing);
+      // for future reference
+      // Verify that our counter starts at 0.
+      // expect(find.text('0'), findsOneWidget);
+      // expect(find.text('1'), findsNothing);
 
-    // Tap the '+' icon and trigger a frame.
-    // await tester.tap(find.byIcon(Icons.add));
-    // await tester.pump();
+      // Tap the '+' icon and trigger a frame.
+      // await tester.tap(find.byIcon(Icons.add));
+      // await tester.pump();
 
-    // Verify that our counter has incremented.
-    // expect(find.text('0'), findsNothing);
-    // expect(find.text('1'), findsOneWidget);
-  });
+      // Verify that our counter has incremented.
+      // expect(find.text('0'), findsNothing);
+      // expect(find.text('1'), findsOneWidget);
+    },
+  );
 
-  testWidgets('Dispatch Action Test', (WidgetTester tester) async {
-    final Store<AppState> store = Store<AppState>(initialState: AppState.initState());
-    final storeTester = StoreTester<AppState>.from(store);
-    expect(storeTester.state.pageIndex, 0);
-    expect(storeTester.state.todoList, isEmpty);
-    expect(storeTester.state.title, 'Active');
+  testWidgets(
+    'Dispatch Action Test',
+    (WidgetTester tester) async {
+      final Store<AppState> store = Store<AppState>(initialState: AppState.initState());
+      final storeTester = StoreTester<AppState>.from(store);
+      expect(storeTester.state.pageIndex, 0);
+      expect(storeTester.state.todoList, isEmpty);
+      expect(storeTester.state.title, 'Active');
 
-    final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+      final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
 
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(
-      StoreProvider<AppState>(
-        store: store,
-        child: MaterialApp(
-          home: StoreConnector<AppState, MainViewModel>(
-            model: MainViewModel(),
-            builder: (context, viewModel) {
-              return Scaffold(
-                key: scaffoldKey,
-                drawer: Drawer(
-                  child: ListView(
-                    children: [
-                      const SizedBox(height: kToolbarHeight),
-                      TileItem(
-                        iconData: Icons.lightbulb_outline,
-                        title: active,
-                        onTap: (context) {
-                          StoreProvider.dispatch<AppState>(context, ChangeScreenAction(title: 'Active', pageIndex: 0));
-                          Future.delayed(const Duration(milliseconds: 200), () => Navigator.pop(context));
-                        },
-                        focusColor: Colors.blue[600],
-                        isSelected: viewModel.pageIndex == 0,
-                      ),
-                      TileItem(
-                        iconData: Icons.done_all_outlined,
-                        title: accomplished,
-                        onTap: (context) {
-                          StoreProvider.dispatch<AppState>(
-                              context, ChangeScreenAction(title: 'Accomplished', pageIndex: 1));
-                          Future.delayed(const Duration(milliseconds: 200), () => Navigator.pop(context));
-                        },
-                        focusColor: Colors.red[600],
-                        isSelected: viewModel.pageIndex != 0,
-                      ),
-                    ],
+      // Build our app and trigger a frame.
+      await tester.pumpWidget(
+        StoreProvider<AppState>(
+          store: store,
+          child: MaterialApp(
+            home: StoreConnector<AppState, MainViewModel>(
+              model: MainViewModel(),
+              builder: (context, viewModel) {
+                return Scaffold(
+                  key: scaffoldKey,
+                  drawer: Drawer(
+                    child: ListView(
+                      children: [
+                        const SizedBox(height: kToolbarHeight),
+                        TileItem(
+                          iconData: Icons.lightbulb_outline,
+                          title: active,
+                          onTap: (context) {
+                            StoreProvider.dispatch<AppState>(
+                                context, ChangeScreenAction(title: 'Active', pageIndex: 0));
+                            Future.delayed(const Duration(milliseconds: 200), () => Navigator.pop(context));
+                          },
+                          focusColor: Colors.blue[600],
+                          isSelected: viewModel.pageIndex == 0,
+                        ),
+                        TileItem(
+                          iconData: Icons.done_all_outlined,
+                          title: accomplished,
+                          onTap: (context) {
+                            StoreProvider.dispatch<AppState>(
+                                context, ChangeScreenAction(title: 'Accomplished', pageIndex: 1));
+                            Future.delayed(const Duration(milliseconds: 200), () => Navigator.pop(context));
+                          },
+                          focusColor: Colors.red[600],
+                          isSelected: viewModel.pageIndex != 0,
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-              );
-            },
+                );
+              },
+            ),
+            initialRoute: HomePage.route,
+            onGenerateRoute: AppRouter.generateRoute,
           ),
-          initialRoute: MyHomePage.route,
-          onGenerateRoute: AppRouter.generateRoute,
         ),
-      ),
-    );
+      );
 
-    await tester.pump(); // trigger frame
-    expect(find.byType(Drawer), findsNothing); // no drawer found
-    scaffoldKey.currentState?.openDrawer(); // opens drawer
+      await tester.pump(); // trigger frame
+      expect(find.byType(Drawer), findsNothing); // no drawer found
+      scaffoldKey.currentState?.openDrawer(); // opens drawer
 
-    await tester.pump(); // drawer should have started animating at this point
-    expect(find.text('Active'), findsOneWidget); // after opening drawer, widget with a text of 'Active' exists
-    await tester.tap(find.byType(Container).at(1)); // click widget with text of 'Accomplished'
-    storeTester
-        .dispatch(ChangeScreenAction(title: 'Accomplished', pageIndex: 1)); // set title: 'Accomplished', pageIndex: 1
-    await tester.pump(const Duration(milliseconds: 200)); // must animate after 200 milliseconds
+      await tester.pump(); // drawer should have started animating at this point
+      expect(find.text('Active'), findsOneWidget); // after opening drawer, widget with a text of 'Active' exists
+      await tester.tap(find.byType(Container).at(1)); // click widget with text of 'Accomplished'
+      storeTester
+          .dispatch(ChangeScreenAction(title: 'Accomplished', pageIndex: 1)); // set title: 'Accomplished', pageIndex: 1
+      await tester.pump(const Duration(milliseconds: 200)); // must animate after 200 milliseconds
 
-    await tester.pump(); // trigger frame again
-    expect(find.byType(Drawer), findsNothing); // no drawer found
-    scaffoldKey.currentState?.openDrawer(); // opens drawer again
+      await tester.pump(); // trigger frame again
+      expect(find.byType(Drawer), findsNothing); // no drawer found
+      scaffoldKey.currentState?.openDrawer(); // opens drawer again
 
-    await tester.pump(); // trigger frame containing drawer items
-    expect(find.text('Accomplished'), findsOneWidget); // opens drawer, must have widget with a text of 'Accomplished'
-    final TestInfo<AppState> info = await storeTester.wait(ChangeScreenAction); // get updated state
-    expect(info.state.title, 'Accomplished'); // expected title: 'Accomplished'
-    expect(info.state.pageIndex, 1); // expected pageIndex: 1
-    await tester.tap(find.byType(Container).at(0)); // click widget with a text of 'Active'
-    storeTester.dispatch(ChangeScreenAction(title: 'Active', pageIndex: 0)); // set title: 'Active', pageIndex: 0
-    await tester.pump(const Duration(milliseconds: 200)); // must animate after 200 milliseconds
-    final TestInfo<AppState> changeInfo = await storeTester.wait(ChangeScreenAction); // get updated state
-    expect(changeInfo.state.title, 'Active'); // expected title: 'Active'
-    expect(changeInfo.state.pageIndex, 0); // expected pageIndex: 0
-  });
+      await tester.pump(); // trigger frame containing drawer items
+      expect(find.text('Accomplished'), findsOneWidget); // opens drawer, must have widget with a text of 'Accomplished'
+      final TestInfo<AppState> info = await storeTester.wait(ChangeScreenAction); // get updated state
+      expect(info.state.title, 'Accomplished'); // expected title: 'Accomplished'
+      expect(info.state.pageIndex, 1); // expected pageIndex: 1
+      await tester.tap(find.byType(Container).at(0)); // click widget with a text of 'Active'
+      storeTester.dispatch(ChangeScreenAction(title: 'Active', pageIndex: 0)); // set title: 'Active', pageIndex: 0
+      await tester.pump(const Duration(milliseconds: 200)); // must animate after 200 milliseconds
+      final TestInfo<AppState> changeInfo = await storeTester.wait(ChangeScreenAction); // get updated state
+      expect(changeInfo.state.title, 'Active'); // expected title: 'Active'
+      expect(changeInfo.state.pageIndex, 0); // expected pageIndex: 0
+    },
+  );
 }


### PR DESCRIPTION
- decouple classes into separate files from `main.dart` file
- move `navigateToUpdateTodo` method to `home_page.dart`
- create `async_redux_test` for actions test
- remove performing actions from `add_todo_page`, passed values as arguments instead